### PR TITLE
pin weaviate dependency to v4.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pymysql
 pandas
 qdrant-client
 singlestoredb
-weaviate-client
+weaviate-client==v4.9.6
 azure-storage-blob
 google-cloud-storage
 snowflake-connector-python


### PR DESCRIPTION
Weaviate python client 4.9.6 will be the last one to include the v3 client:
https://weaviate.io/developers/weaviate/client-libraries/python/python_v3

This PR will pin this dependency, otherwise new installations will install the latest weaviate-client 4.10.+ package that doesn't ship the v3 code anymore.

